### PR TITLE
Fix for #5

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,7 @@ mod parse_error {
     }
 }
 
-use triple::{Endianness, PointerWidth, Triple};
+use self::triple::{Endianness, PointerWidth, Triple};
 
 /// Assuming `target` is a path to a custom target json config file, open it
 /// and build a `Triple` using its contents.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod targets;
 #[macro_use]
 mod triple;
 
-pub use host::HOST;
-pub use parse_error::ParseError;
-pub use targets::{Architecture, BinaryFormat, Environment, OperatingSystem, Vendor};
-pub use triple::{CallingConvention, Endianness, PointerWidth, Triple};
+pub use self::host::HOST;
+pub use self::parse_error::ParseError;
+pub use self::targets::{Architecture, BinaryFormat, Environment, OperatingSystem, Vendor};
+pub use self::triple::{CallingConvention, Endianness, PointerWidth, Triple};


### PR DESCRIPTION
This commit fixes the errors caused by `uniform_paths`-style `use` statements in the build script described in #5. This commit also changes `use` statements in `src/lib.rs` to use `anchored_use_paths` style for consistency sake.