### PR TITLE
Make `host` a const function

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -121,7 +121,7 @@ fn main() {
 
 fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
     writeln!(out, "/// The `Triple` of the current host.")?;
-    writeln!(out, "pub static HOST: Triple = Triple {{")?;
+    writeln!(out, "pub const HOST: Triple = Triple {{")?;
     writeln!(
         out,
         "    architecture: Architecture::{:?},",

--- a/build.rs
+++ b/build.rs
@@ -148,7 +148,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
 
     writeln!(out, "impl Architecture {{")?;
     writeln!(out, "    /// Return the architecture for the current host.")?;
-    writeln!(out, "    pub fn host() -> Self {{")?;
+    writeln!(out, "    pub const fn host() -> Self {{")?;
     writeln!(out, "        Architecture::{:?}", triple.architecture)?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
@@ -156,7 +156,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
 
     writeln!(out, "impl Vendor {{")?;
     writeln!(out, "    /// Return the vendor for the current host.")?;
-    writeln!(out, "    pub fn host() -> Self {{")?;
+    writeln!(out, "    pub const fn host() -> Self {{")?;
     writeln!(out, "        Vendor::{:?}", triple.vendor)?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
@@ -167,7 +167,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
         out,
         "    /// Return the operating system for the current host."
     )?;
-    writeln!(out, "    pub fn host() -> Self {{")?;
+    writeln!(out, "    pub const fn host() -> Self {{")?;
     writeln!(
         out,
         "        OperatingSystem::{:?}",
@@ -179,7 +179,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
 
     writeln!(out, "impl Environment {{")?;
     writeln!(out, "    /// Return the environment for the current host.")?;
-    writeln!(out, "    pub fn host() -> Self {{")?;
+    writeln!(out, "    pub const fn host() -> Self {{")?;
     writeln!(out, "        Environment::{:?}", triple.environment)?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
@@ -190,7 +190,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
         out,
         "    /// Return the binary format for the current host."
     )?;
-    writeln!(out, "    pub fn host() -> Self {{")?;
+    writeln!(out, "    pub const fn host() -> Self {{")?;
     writeln!(out, "        BinaryFormat::{:?}", triple.binary_format)?;
     writeln!(out, "    }}")?;
     writeln!(out, "}}")?;
@@ -198,7 +198,7 @@ fn write_host_rs(mut out: File, triple: Triple) -> io::Result<()> {
 
     writeln!(out, "impl Triple {{")?;
     writeln!(out, "    /// Return the triple for the current host.")?;
-    writeln!(out, "    pub fn host() -> Self {{")?;
+    writeln!(out, "    pub const fn host() -> Self {{")?;
     writeln!(out, "        Self {{")?;
     writeln!(
         out,

--- a/examples/host.rs
+++ b/examples/host.rs
@@ -1,0 +1,14 @@
+extern crate target_lexicon;
+
+use target_lexicon::Triple;
+
+const HOST: Triple = Triple::host();
+
+fn main() {
+    println!(
+        "{}",
+        HOST.pointer_width()
+            .expect("architecture should be known")
+            .bytes()
+    );
+}

--- a/examples/host.rs
+++ b/examples/host.rs
@@ -1,8 +1,6 @@
 extern crate target_lexicon;
 
-use target_lexicon::Triple;
-
-const HOST: Triple = Triple::host();
+use target_lexicon::HOST;
 
 fn main() {
     println!(


### PR DESCRIPTION
Allows using `host` for initializing `const` and `static` values.
Adds an example of using host in a const context.

Affects the following enums and structs:
- `Architecture`
- `Vendor`
- `OperatingSystem`
- `Environment`
- `BinaryFormat`
- `Triple`

Addresses https://github.com/CraneStation/target-lexicon/issues/18