### PR TITLE
Update no_std support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,6 @@ failure_derive = { version = "0.1.3", default-features = false }
 [build-dependencies]
 serde_json = "1.0"
 
-[features]
-default = ["std"]
-std = []
-
 [badges]
 maintenance = { status = "passively-maintained" }
 travis-ci = { repository = "CraneStation/target-lexicon" }

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+extern crate alloc;
 extern crate serde_json;
 
 // Include triple.rs and targets.rs so we can parse the TARGET environment variable.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,8 @@
     )
 )]
 #![no_std]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
-#[cfg(not(feature = "std"))]
-extern crate alloc as std;
-#[cfg(feature = "std")]
-extern crate std;
+extern crate alloc;
 
 #[macro_use]
 extern crate failure_derive;

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -1,4 +1,4 @@
-use std::string::String;
+use alloc::string::String;
 
 /// An error returned from parsing a triple.
 #[derive(Fail, Clone, Debug, PartialEq, Eq)]

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -927,7 +927,7 @@ impl FromStr for BinaryFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::string::ToString;
+    use alloc::string::ToString;
 
     #[test]
     fn roundtrip_known_triples() {

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -5,9 +5,9 @@ use crate::targets::{
     default_binary_format, Architecture, ArmArchitecture, BinaryFormat, Environment,
     OperatingSystem, Vendor,
 };
+use alloc::borrow::ToOwned;
 use core::fmt;
 use core::str::FromStr;
-use std::borrow::ToOwned;
 
 /// The target memory endianness.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
liballoc is now stable as of Rust 1.36, so use it to simplify no_std
support. target-lexicon can now just support no_std by default, without
using cargo features.