### PR TITLE
Update target list and bump to 0.9.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "target-lexicon"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Dan Gohman <sunfish@mozilla.com>"]
 description = "Targeting utilities for compilers and related tools"
 documentation = "https://docs.rs/target-lexicon/"

--- a/src/targets.rs
+++ b/src/targets.rs
@@ -364,8 +364,10 @@ pub enum Environment {
     Musleabihf,
     Muslabi64,
     Msvc,
+    Kernel,
     Uclibc,
     Sgx,
+    Softfloat,
     Spe,
 }
 
@@ -867,8 +869,10 @@ impl fmt::Display for Environment {
             Environment::Musleabihf => "musleabihf",
             Environment::Muslabi64 => "muslabi64",
             Environment::Msvc => "msvc",
+            Environment::Kernel => "kernel",
             Environment::Uclibc => "uclibc",
             Environment::Sgx => "sgx",
+            Environment::Softfloat => "softfloat",
             Environment::Spe => "spe",
         };
         f.write_str(s)
@@ -897,8 +901,10 @@ impl FromStr for Environment {
             "musleabihf" => Environment::Musleabihf,
             "muslabi64" => Environment::Muslabi64,
             "msvc" => Environment::Msvc,
+            "kernel" => Environment::Kernel,
             "uclibc" => Environment::Uclibc,
             "sgx" => Environment::Sgx,
+            "softfloat" => Environment::Softfloat,
             "spe" => Environment::Spe,
             _ => return Err(()),
         })
@@ -956,6 +962,7 @@ mod tests {
             "aarch64-unknown-linux-musl",
             "aarch64-unknown-netbsd",
             "aarch64-unknown-none",
+            "aarch64-unknown-none-softfloat",
             "aarch64-unknown-openbsd",
             "aarch64-unknown-redox",
             "aarch64-uwp-windows-msvc",
@@ -1006,6 +1013,7 @@ mod tests {
             "i686-unknown-linux-musl",
             "i686-unknown-netbsd",
             "i686-unknown-openbsd",
+            "i686-unknown-uefi",
             "i686-uwp-windows-gnu",
             "i686-uwp-windows-msvc",
             "i686-wrs-vxworks",
@@ -1067,6 +1075,7 @@ mod tests {
             "x86_64-fortanix-unknown-sgx",
             "x86_64-fuchsia",
             "x86_64-linux-android",
+            "x86_64-linux-kernel",
             "x86_64-apple-macosx10.7.0",
             "x86_64-pc-solaris",
             "x86_64-pc-windows-gnu",

--- a/src/triple.rs
+++ b/src/triple.rs
@@ -179,7 +179,8 @@ impl fmt::Display for Triple {
         if self.vendor == Vendor::Unknown
             && ((self.operating_system == OperatingSystem::Linux
                 && (self.environment == Environment::Android
-                    || self.environment == Environment::Androideabi))
+                    || self.environment == Environment::Androideabi
+                    || self.environment == Environment::Kernel))
                 || self.operating_system == OperatingSystem::Fuchsia
                 || self.operating_system == OperatingSystem::Wasi
                 || (self.operating_system == OperatingSystem::None_
@@ -190,7 +191,8 @@ impl fmt::Display for Triple {
                         || self.architecture == Architecture::Arm(ArmArchitecture::Thumbv7m)
                         || self.architecture == Architecture::Arm(ArmArchitecture::Thumbv8mBase)
                         || self.architecture == Architecture::Arm(ArmArchitecture::Thumbv8mMain)
-                        || self.architecture == Architecture::Msp430)))
+                        || self.architecture == Architecture::Msp430
+                        || self.architecture == Architecture::X86_64)))
         {
             // As a special case, omit the vendor for Android, Fuchsia, Wasi, and sometimes
             // None_, depending on the hardware architecture. This logic is entirely
@@ -275,17 +277,19 @@ impl FromStr for Triple {
         }
 
         if let Some(s) = current_part {
-            Err(if !has_vendor {
-                ParseError::UnrecognizedVendor(s.to_owned())
-            } else if !has_operating_system {
-                ParseError::UnrecognizedOperatingSystem(s.to_owned())
-            } else if !has_environment {
-                ParseError::UnrecognizedEnvironment(s.to_owned())
-            } else if !has_binary_format {
-                ParseError::UnrecognizedBinaryFormat(s.to_owned())
-            } else {
-                ParseError::UnrecognizedField(s.to_owned())
-            })
+            Err(
+                if !has_vendor && !has_operating_system && !has_environment && !has_binary_format {
+                    ParseError::UnrecognizedVendor(s.to_owned())
+                } else if !has_operating_system && !has_environment && !has_binary_format {
+                    ParseError::UnrecognizedOperatingSystem(s.to_owned())
+                } else if !has_environment && !has_binary_format {
+                    ParseError::UnrecognizedEnvironment(s.to_owned())
+                } else if !has_binary_format {
+                    ParseError::UnrecognizedBinaryFormat(s.to_owned())
+                } else {
+                    ParseError::UnrecognizedField(s.to_owned())
+                },
+            )
         } else {
             Ok(result)
         }


### PR DESCRIPTION
This updates to the list of targets in the lastest Rust builds, and bumps the version number for publishing.